### PR TITLE
Allocate domain dynamically

### DIFF
--- a/source/cylind_var.c
+++ b/source/cylind_var.c
@@ -922,47 +922,43 @@ cylvar_coord_fraction (ndom, ichoice, x, ii, frac, nelem)
 
 }
 
-
 /**********************************************************/
 /**
- * @brief
+ * @brief Allocate memory for a cylindrical variable domain.
  *
- * @return
+ * @param [in] ndom  The domain to allocate for
  *
  * @details
  *
+ * Allocates memory for `wind_z_var` and `wind_midz_var`, both of which are
+ * 2D arrays. Memory for each array should be contiguous, as we are using a
+ * pointer arithmetic trick to allocate the memory required to element 0 and
+ * then manually arranging the memory for the other elements.
  *
  **********************************************************/
 
 void
 cylvar_allocate_domain (int ndom)
 {
+  /* Allocate memory for rows, then allocate enough memory for the entire
+   * array to element 0 */
   zdom[ndom].wind_z_var = calloc (zdom[ndom].ndim, sizeof (double *));
-  if (zdom[ndom].wind_z_var == NULL)
+  zdom[ndom].wind_midz_var = calloc (zdom[ndom].ndim, sizeof (double *));
+  if (zdom[ndom].wind_z_var == NULL || zdom[ndom].wind_midz_var == NULL)
   {
-    Error ("");
+    Error ("cylvar_allocate_domain: failed to allocate memory for cylvar domain coordinates\n");
     Exit (EXIT_FAILURE);
   }
   zdom[ndom].wind_z_var[0] = calloc (zdom[ndom].ndim * zdom[ndom].mdim, sizeof (double));
-  if (zdom[ndom].wind_z_var[0] == NULL)
-  {
-    Error ("");
-    Exit (EXIT_FAILURE);
-  }
-
-  zdom[ndom].wind_midz_var = calloc (zdom[ndom].ndim, sizeof (double *));
-  if (zdom[ndom].wind_midz_var == NULL)
-  {
-    Error ("");
-    Exit (EXIT_FAILURE);
-  }
   zdom[ndom].wind_midz_var[0] = calloc (zdom[ndom].ndim * zdom[ndom].mdim, sizeof (double));
-  if (zdom[ndom].wind_midz_var[0] == NULL)
+  if (zdom[ndom].wind_z_var[0] == NULL || zdom[ndom].wind_midz_var[0])
   {
-    Error ("");
+    Error ("cylvar_allocate_domain: failed to allocate memory for cylvar domain coordinates\n");
     Exit (EXIT_FAILURE);
   }
 
+  /* Now manually rearrange the memory from element 0 to fill out the other
+   * rows with columns */
   for (int row = 1; row < zdom[ndom].ndim; ++row)
   {
     zdom[ndom].wind_z_var[row] = zdom[ndom].wind_z_var[row - 1] + zdom[ndom].mdim;

--- a/source/cylind_var.c
+++ b/source/cylind_var.c
@@ -921,3 +921,51 @@ cylvar_coord_fraction (ndom, ichoice, x, ii, frac, nelem)
   return (1);
 
 }
+
+
+/**********************************************************/
+/**
+ * @brief
+ *
+ * @return
+ *
+ * @details
+ *
+ *
+ **********************************************************/
+
+void
+cylvar_allocate_domain (int ndom)
+{
+  zdom[ndom].wind_z_var = calloc (zdom[ndom].ndim, sizeof (double *));
+  if (zdom[ndom].wind_z_var == NULL)
+  {
+    Error ("");
+    Exit (EXIT_FAILURE);
+  }
+  zdom[ndom].wind_z_var[0] = calloc (zdom[ndom].ndim * zdom[ndom].mdim, sizeof (double));
+  if (zdom[ndom].wind_z_var[0] == NULL)
+  {
+    Error ("");
+    Exit (EXIT_FAILURE);
+  }
+
+  zdom[ndom].wind_midz_var = calloc (zdom[ndom].ndim, sizeof (double *));
+  if (zdom[ndom].wind_midz_var == NULL)
+  {
+    Error ("");
+    Exit (EXIT_FAILURE);
+  }
+  zdom[ndom].wind_midz_var[0] = calloc (zdom[ndom].ndim * zdom[ndom].mdim, sizeof (double));
+  if (zdom[ndom].wind_midz_var[0] == NULL)
+  {
+    Error ("");
+    Exit (EXIT_FAILURE);
+  }
+
+  for (int row = 1; row < zdom[ndom].ndim; ++row)
+  {
+    zdom[ndom].wind_z_var[row] = zdom[ndom].wind_z_var[row - 1] + zdom[ndom].mdim;
+    zdom[ndom].wind_midz_var[row] = zdom[ndom].wind_midz_var[row - 1] + zdom[ndom].mdim;
+  }
+}

--- a/source/import_calloc.c
+++ b/source/import_calloc.c
@@ -40,10 +40,10 @@ calloc_import (int coord_type, int ndom)
 {
   if (imported_model == NULL)
   {
-    imported_model = calloc (MaxDom, sizeof *imported_model);
+    imported_model = calloc (MAX_DOM, sizeof *imported_model);
     if (imported_model == NULL)
     {
-      Error ("calloc_import: unable to allocate %i domains for imported_model\n", MaxDom);
+      Error ("calloc_import: unable to allocate %i domains for imported_model\n", MAX_DOM);
       Exit (1);
     }
   }

--- a/source/import_cylindrical.c
+++ b/source/import_cylindrical.c
@@ -298,8 +298,8 @@ import_cylindrical_setup_boundaries (int ndom)
     }
   }
 
-  zdom[ndom].wind_rhomin_at_disk = zdom[ndom].rho_min = rho_min;
-  zdom[ndom].wind_rhomax_at_disk = zdom[ndom].rho_max = rho_max;
+  zdom[ndom].wind_rhomin_at_disk = rho_min;
+  zdom[ndom].wind_rhomax_at_disk = rho_max;
   zdom[ndom].zmax = zmax;
   zdom[ndom].zmin = zmin;
 

--- a/source/import_rtheta.c
+++ b/source/import_rtheta.c
@@ -321,8 +321,8 @@ import_rtheta_setup_boundaries (int ndom)
     }
   }
 
-  zdom[ndom].wind_rhomin_at_disk = zdom[ndom].rho_min = rho_min;
-  zdom[ndom].wind_rhomax_at_disk = zdom[ndom].rho_max = rho_max;
+  zdom[ndom].wind_rhomin_at_disk = rho_min;
+  zdom[ndom].wind_rhomax_at_disk = rho_max;
   zdom[ndom].zmax = zmax;
 
   zdom[ndom].rmax = rmax;

--- a/source/import_spherical.c
+++ b/source/import_spherical.c
@@ -177,9 +177,9 @@ import_1d (ndom, filename)
 int
 import_spherical_setup_boundaries (int ndom)
 {
-  zdom[ndom].wind_rhomin_at_disk = zdom[ndom].rho_min = 0;
+  zdom[ndom].wind_rhomin_at_disk = 0;
   zdom[ndom].rmin = imported_model[ndom].r[1];  // <- this assumes the 1st cell is a ghost cell
-  zdom[ndom].wind_rhomax_at_disk = zdom[ndom].zmax = zdom[ndom].rho_max = zdom[ndom].rmax = imported_model[ndom].r[imported_model[ndom].ncell - 2];     // <- this assumes the last 2 cells are ghost cells
+  zdom[ndom].wind_rhomax_at_disk = zdom[ndom].zmax = zdom[ndom].rmax = imported_model[ndom].r[imported_model[ndom].ncell - 2];  // <- this assumes the last 2 cells are ghost cells
   zdom[ndom].wind_thetamin = zdom[ndom].wind_thetamax = 0;
 
   return 0;

--- a/source/janitor.c
+++ b/source/janitor.c
@@ -16,6 +16,42 @@
 
 /**********************************************************/
 /**
+ * @brief  Free memory associated with the domains
+ *
+ * @details
+ *
+ **********************************************************/
+
+void
+free_domains (void)
+{
+  int i;
+
+  for (i = 0; i < geo.ndomain; ++i)
+  {
+    free (zdom[i].wind_x);
+    free (zdom[i].wind_midx);
+    free (zdom[i].wind_z);
+    free (zdom[i].wind_midz);
+
+    if (zdom[i].coord_type == RTHETA)
+    {
+      free (zdom[i].cones_rtheta);
+    }
+    else if (zdom[i].coord_type == CYLVAR)
+    {
+      free (zdom[i].wind_z_var[0]);
+      free (zdom[i].wind_z_var);
+      free (zdom[i].wind_midz_var[0]);
+      free (zdom[i].wind_midz_var);
+    }
+  }
+
+  free (zdom);
+}
+
+/**********************************************************/
+/**
  * @brief  Free memory associated with the wind grid
  *
  * @details
@@ -189,7 +225,7 @@ free_spectra (void)
 void
 clean_on_exit (void)
 {
-  free (zdom);
+  free_domains ();
   free_wind_grid ();
   free_plasma_grid ();
   if (nlevels_macro > 0)

--- a/source/photon_gen.c
+++ b/source/photon_gen.c
@@ -405,9 +405,9 @@ iwind = -1 	Don't generate any wind photons at all
       geo.lum_wind = wind_luminosity (0.0, VERY_BIG, MODE_CMF_TIME);
     }
 
-    xxxpdfwind = 1;             // Turn on the portion of the line luminosity routine which creates pdfs
+//    xxxpdfwind = 1;             // Turn on the portion of the line luminosity routine which creates pdfs
     geo.f_wind = wind_luminosity (f1, f2, MODE_OBSERVER_FRAME_TIME);
-    xxxpdfwind = 0;             // Turn off the portion of the line luminosity routine which creates pdfs
+//    xxxpdfwind = 0;             // Turn off the portion of the line luminosity routine which creates pdfs
 
   }
 

--- a/source/python.c
+++ b/source/python.c
@@ -173,7 +173,7 @@ main (argc, argv)
 
 /* Allocate the domain structure */
 
-  zdom = (DomainPtr) calloc (sizeof (domain_dummy), MaxDom);
+  zdom = (DomainPtr) calloc (sizeof (domain_dummy), MAX_DOM);
 
   /* BEGIN GATHERING INPUT DATA */
 
@@ -317,29 +317,27 @@ main (argc, argv)
         geo.ndomain = 1;
         rdint ("Wind.number_of_components", &geo.ndomain);
 
-        if (geo.ndomain > MaxDom)
+        if (geo.ndomain > MAX_DOM)
         {
-          Error ("Maximum number of wind components allowed is %d\n", MaxDom);
+          Error ("Maximum number of wind components allowed is %d\n", MAX_DOM);
           Exit (EXIT_FAILURE);
         }
 
         for (n = 0; n < geo.ndomain; n++)
         {
-
           get_domain_params (n);
-
         }
       }
 
     }
   }
 
-  /* zdom only temporarily needs to be MaxDom. Now that we know the number of domains, we'll reallocate
+  /* zdom only temporarily needs to be MAX_DOM. Now that we know the number of domains, we'll reallocate
    * the domain to make it smaller */
   zdom = realloc (zdom, sizeof (domain_dummy) * geo.ndomain);
   if (zdom == NULL)
   {
-    Error ("python: unable to re-allocate space for domain structure from %d domains to %d domains\n", MaxDom, geo.ndomain);
+    Error ("python: unable to re-allocate space for domain structure from %d domains to %d domains\n", MAX_DOM, geo.ndomain);
     Exit (EXIT_FAILURE);
   }
 

--- a/source/python_extern_init.c
+++ b/source/python_extern_init.c
@@ -56,10 +56,6 @@ int NWAVE_NOW;                  ///< Either NWAVE_IONIZ or NWAVE_EXTRACT dependi
 
 plane_dummy plane_m2_near, plane_m2_far;
 
-double x_axis[3];
-double y_axis[3];
-double z_axis[3];
-
 DomainPtr zdom;                 ///< This is the array pointer that contains the domains
 int current_domain;             ///<  This integer is used by py_wind only
 
@@ -82,7 +78,7 @@ MatomPhotStorePtr matomphotstoremain;
 
 MacroPtr macromain;
 
-int xxxpdfwind;                 ///< When 1, line luminosity calculates pdf
+//int xxxpdfwind;                 ///< When 1, line luminosity calculates pdf
 
 int size_Jbar_est, size_gamma_est, size_alpha_est;
 
@@ -135,7 +131,7 @@ int xxxbound;
 
 struct rdpar_choices zz_spec;
 
-struct Import *imported_model;  ///<  MaxDom is defined in python.h and as such import.h has to be included after
+struct Import *imported_model;  ///<  MAX_DOM is defined in python.h and as such import.h has to be included after
 
 
 double velocity_electron[3];    // velocity of the electron when thermal effects are included

--- a/source/setup.c
+++ b/source/setup.c
@@ -123,23 +123,13 @@ init_geo ()
   geo.lamp_post_height = 0.0;   // should only be used if geo.pl_geometry is PL_GEOMETRY_LAMP_POST
   geo.bubble_size = 0.0;        // should only be used if geo.pl_geometry is PL_GEOMETRY_BUBBLE_
 
-
   strcpy (geo.atomic_filename, "data/standard80.dat");
   strcpy (geo.fixed_con_file, "none");
-
-  // Note that geo.model_list is initialized through get_spectype
-
-  /* Initialize a few other variables in python.h */
-  x_axis[0] = 1.0;
-  x_axis[1] = x_axis[2] = 0.0;
-  y_axis[1] = 1.0;
-  y_axis[0] = y_axis[2] = 0.0;
-  z_axis[2] = 1.0;
-  z_axis[1] = z_axis[0] = 0.0;
 
   geo.wcycles = geo.pcycles = 1;
   geo.wcycle = geo.pcycle = 0;
 
+  // Note that geo.model_list is initialized through get_spectype
   geo.model_count = 0;          //The number of models read in
 
   /* We should set the frame ASAP in the geo struct, so the grid initialisation

--- a/source/stellar_wind.c
+++ b/source/stellar_wind.c
@@ -79,7 +79,7 @@ get_stellar_wind_params (ndom)
 
   /* define the the variables that determine the gridding */
   zdom[ndom].wind_rhomin_at_disk = 0;
-  zdom[ndom].wind_rhomax_at_disk = zdom[ndom].rho_max = zdom[ndom].rmax;
+  zdom[ndom].wind_rhomax_at_disk = zdom[ndom].rmax;
   zdom[ndom].zmax = zdom[ndom].rmax;
 
 

--- a/source/templates.h
+++ b/source/templates.h
@@ -548,7 +548,7 @@ void setup_atomic_data(const char *atomic_filename);
 double get_disk_params(void);
 /* setup_domains.c */
 int get_domain_params(int ndom);
-void allocate_domain_coords(int ndom);
+void allocate_domain_wind_coords(int ndom);
 int get_wind_params(int ndom);
 int setup_windcone(void);
 int init_windcone(double r, double z, double dzdr, int allow_negative_dzdr, ConePtr one_windcone);

--- a/source/templates.h
+++ b/source/templates.h
@@ -118,6 +118,7 @@ int cylvar_where_in_grid(int ndom, double x[], int ichoice, double *fx, double *
 int cylvar_get_random_location(int n, double x[]);
 int cylvar_extend_density(int ndom, WindPtr w);
 int cylvar_coord_fraction(int ndom, int ichoice, double x[], int ii[], double frac[], int *nelem);
+void cylvar_allocate_domain(int ndom);
 /* cylindrical.c */
 double cylind_ds_in_cell(int ndom, PhotPtr p);
 int cylind_make_grid(int ndom, WindPtr w);
@@ -290,6 +291,7 @@ double calc_te(PlasmaPtr xplasma, double tmin, double tmax);
 double zero_emit(double t);
 double zero_emit2(double t, void *params);
 /* janitor.c */
+void free_domains(void);
 void free_wind_grid(void);
 void free_plasma_grid(void);
 void free_macro_grid(void);
@@ -546,6 +548,7 @@ void setup_atomic_data(const char *atomic_filename);
 double get_disk_params(void);
 /* setup_domains.c */
 int get_domain_params(int ndom);
+void allocate_domain_coords(int ndom);
 int get_wind_params(int ndom);
 int setup_windcone(void);
 int init_windcone(double r, double z, double dzdr, int allow_negative_dzdr, ConePtr one_windcone);

--- a/source/tests/tests/test_define_wind.c
+++ b/source/tests/tests/test_define_wind.c
@@ -256,7 +256,7 @@ initialise_model_for_define_wind (const char *root_name)
     return EXIT_FAILURE;
   }
 
-  zdom = calloc (MaxDom, sizeof (domain_dummy));        /* We'll allocate MaxDom to follow python */
+  zdom = calloc (MAX_DOM, sizeof (domain_dummy));       /* We'll allocate MAX_DOM to follow python */
   if (zdom == NULL)
   {
     fprintf (stderr, "Unable to allocate space for domain structure\n");
@@ -267,9 +267,9 @@ initialise_model_for_define_wind (const char *root_name)
   /* Now when we call the initialisation functions or use rdXXX, the rdchoice_choices
    * for the parameter will come from the parameter file */
   rdint ("Wind.number_of_components", &geo.ndomain);
-  if (geo.ndomain > MaxDom)
+  if (geo.ndomain > MAX_DOM)
   {
-    fprintf (stderr, "Using more domains (%d) in model than MaxDom (%d)\n", geo.ndomain, MaxDom);
+    fprintf (stderr, "Using more domains (%d) in model than MAX_DOM (%d)\n", geo.ndomain, MAX_DOM);
     return EXIT_FAILURE;
   }
   strncpy (rdchoice_answer, "star", LINELENGTH);

--- a/source/windsave.c
+++ b/source/windsave.c
@@ -56,7 +56,8 @@ wind_save (filename)
 {
   FILE *fptr;
   char header[LINELENGTH];
-  int n, m;
+  int ndom;
+  int n;
 
   if ((fptr = fopen (filename, "w")) == NULL)
   {
@@ -68,6 +69,23 @@ wind_save (filename)
   n = fwrite (header, sizeof (header), 1, fptr);
   n += fwrite (&geo, sizeof (geo), 1, fptr);
   n += fwrite (zdom, sizeof (domain_dummy), geo.ndomain, fptr);
+
+  for (ndom = 0; ndom < geo.ndomain; ++ndom)
+  {
+    allocate_domain_coords (ndom);
+    fwrite (zdom[ndom].wind_x, sizeof (*zdom[ndom].wind_x), zdom[ndom].ndim, fptr);
+    fwrite (zdom[ndom].wind_z, sizeof (*zdom[ndom].wind_z), zdom[ndom].mdim, fptr);
+    fwrite (zdom[ndom].wind_midx, sizeof (*zdom[ndom].wind_midx), zdom[ndom].ndim, fptr);
+    fwrite (zdom[ndom].wind_midz, sizeof (*zdom[ndom].wind_midz), zdom[ndom].mdim, fptr);
+
+    if (zdom[ndom].coord_type == CYLVAR)
+    {
+      cylvar_allocate_domain (ndom);
+      fwrite (zdom[ndom].wind_z_var, sizeof (*zdom[ndom].wind_z_var), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
+      fwrite (zdom[ndom].wind_midz_var, sizeof (*zdom[ndom].wind_midz_var), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
+    }
+  }
+
   n += fwrite (wmain, sizeof (wind_dummy), NDIM2, fptr);
   n += fwrite (&disk, sizeof (disk), 1, fptr);
   n += fwrite (&qdisk, sizeof (disk), 1, fptr);
@@ -76,29 +94,29 @@ wind_save (filename)
 /* Write out the variable length arrays
 in the plasma structure */
 
-  for (m = 0; m < NPLASMA; m++)
+  for (ndom = 0; ndom < NPLASMA; ndom++)
   {
-    n += fwrite (plasmamain[m].density, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[m].partition, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].density, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].partition, sizeof (double), nions, fptr);
 
-    n += fwrite (plasmamain[m].ioniz, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[m].recomb, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[m].inner_recomb, sizeof (double), nions, fptr);
-
-
-    n += fwrite (plasmamain[m].scatters, sizeof (int), nions, fptr);
-    n += fwrite (plasmamain[m].xscatters, sizeof (double), nions, fptr);
-
-    n += fwrite (plasmamain[m].heat_ion, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[m].cool_rr_ion, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[m].cool_dr_ion, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[m].lum_rr_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].ioniz, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].recomb, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].inner_recomb, sizeof (double), nions, fptr);
 
 
-    n += fwrite (plasmamain[m].levden, sizeof (double), nlte_levels, fptr);
-    n += fwrite (plasmamain[m].recomb_simple, sizeof (double), nphot_total, fptr);
-    n += fwrite (plasmamain[m].recomb_simple_upweight, sizeof (double), nphot_total, fptr);
-    n += fwrite (plasmamain[m].kbf_use, sizeof (double), nphot_total, fptr);
+    n += fwrite (plasmamain[ndom].scatters, sizeof (int), nions, fptr);
+    n += fwrite (plasmamain[ndom].xscatters, sizeof (double), nions, fptr);
+
+    n += fwrite (plasmamain[ndom].heat_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].cool_rr_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].cool_dr_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[ndom].lum_rr_ion, sizeof (double), nions, fptr);
+
+
+    n += fwrite (plasmamain[ndom].levden, sizeof (double), nlte_levels, fptr);
+    n += fwrite (plasmamain[ndom].recomb_simple, sizeof (double), nphot_total, fptr);
+    n += fwrite (plasmamain[ndom].recomb_simple_upweight, sizeof (double), nphot_total, fptr);
+    n += fwrite (plasmamain[ndom].kbf_use, sizeof (double), nphot_total, fptr);
   }
 
 /* Now write out the macro atom info */
@@ -106,22 +124,22 @@ in the plasma structure */
   if (geo.nmacro)
   {
     n += fwrite (macromain, sizeof (macro_dummy), NPLASMA, fptr);
-    for (m = 0; m < NPLASMA; m++)
+    for (ndom = 0; ndom < NPLASMA; ndom++)
     {
-      n += fwrite (macromain[m].jbar, sizeof (double), size_Jbar_est, fptr);
-      n += fwrite (macromain[m].jbar_old, sizeof (double), size_Jbar_est, fptr);
-      n += fwrite (macromain[m].gamma, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].gamma_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].gamma_e, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].gamma_e_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].alpha_st, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].alpha_st_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].alpha_st_e, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].alpha_st_e_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[m].recomb_sp, sizeof (double), size_alpha_est, fptr);
-      n += fwrite (macromain[m].recomb_sp_e, sizeof (double), size_alpha_est, fptr);
-      n += fwrite (macromain[m].matom_emiss, sizeof (double), nlevels_macro, fptr);
-      n += fwrite (macromain[m].matom_abs, sizeof (double), nlevels_macro, fptr);
+      n += fwrite (macromain[ndom].jbar, sizeof (double), size_Jbar_est, fptr);
+      n += fwrite (macromain[ndom].jbar_old, sizeof (double), size_Jbar_est, fptr);
+      n += fwrite (macromain[ndom].gamma, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].gamma_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].gamma_e, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].gamma_e_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].alpha_st, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].alpha_st_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].alpha_st_e, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].alpha_st_e_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[ndom].recomb_sp, sizeof (double), size_alpha_est, fptr);
+      n += fwrite (macromain[ndom].recomb_sp_e, sizeof (double), size_alpha_est, fptr);
+      n += fwrite (macromain[ndom].matom_emiss, sizeof (double), nlevels_macro, fptr);
+      n += fwrite (macromain[ndom].matom_abs, sizeof (double), nlevels_macro, fptr);
 
     }
 
@@ -180,6 +198,7 @@ wind_read (filename)
      char filename[];
 {
   FILE *fptr;
+  int i;
   int n, m;
   char header[LINELENGTH];
   char version[LINELENGTH];
@@ -221,6 +240,19 @@ wind_read (filename)
   NPLASMA = geo.nplasma;
 
   n += fread (zdom, sizeof (domain_dummy), geo.ndomain, fptr);
+
+  for (i = 0; i < geo.ndomain; ++i)
+  {
+    fread (zdom[i].wind_x, sizeof (*zdom[i].wind_x), zdom[i].ndim, fptr);
+    fread (zdom[i].wind_z, sizeof (*zdom[i].wind_z), zdom[i].mdim, fptr);
+    fread (zdom[i].wind_midx, sizeof (*zdom[i].wind_midx), zdom[i].ndim, fptr);
+    fread (zdom[i].wind_midz, sizeof (*zdom[i].wind_midz), zdom[i].mdim, fptr);
+    if (zdom[i].coord_type == CYLVAR)
+    {
+      fread (zdom[i].wind_z_var, sizeof (*zdom[i].wind_z_var), zdom[i].ndim * zdom[i].mdim, fptr);
+      fread (zdom[i].wind_midz_var, sizeof (*zdom[i].wind_midz_var), zdom[i].ndim * zdom[i].mdim, fptr);
+    }
+  }
 
   calloc_wind (NDIM2);
   n += fread (wmain, sizeof (wind_dummy), NDIM2, fptr);

--- a/source/windsave.c
+++ b/source/windsave.c
@@ -57,6 +57,7 @@ wind_save (filename)
   FILE *fptr;
   char header[LINELENGTH];
   int ndom;
+  int m;
   int n;
 
   if ((fptr = fopen (filename, "w")) == NULL)
@@ -68,21 +69,19 @@ wind_save (filename)
   sprintf (header, "Version %s\n", VERSION);
   n = fwrite (header, sizeof (header), 1, fptr);
   n += fwrite (&geo, sizeof (geo), 1, fptr);
-  n += fwrite (zdom, sizeof (domain_dummy), geo.ndomain, fptr);
 
+  n += fwrite (zdom, sizeof (domain_dummy), geo.ndomain, fptr);
   for (ndom = 0; ndom < geo.ndomain; ++ndom)
   {
-    allocate_domain_coords (ndom);
-    fwrite (zdom[ndom].wind_x, sizeof (*zdom[ndom].wind_x), zdom[ndom].ndim, fptr);
-    fwrite (zdom[ndom].wind_z, sizeof (*zdom[ndom].wind_z), zdom[ndom].mdim, fptr);
-    fwrite (zdom[ndom].wind_midx, sizeof (*zdom[ndom].wind_midx), zdom[ndom].ndim, fptr);
-    fwrite (zdom[ndom].wind_midz, sizeof (*zdom[ndom].wind_midz), zdom[ndom].mdim, fptr);
+    fwrite (zdom[ndom].wind_x, sizeof (double), zdom[ndom].ndim, fptr);
+    fwrite (zdom[ndom].wind_z, sizeof (double), zdom[ndom].mdim, fptr);
+    fwrite (zdom[ndom].wind_midx, sizeof (double), zdom[ndom].ndim, fptr);
+    fwrite (zdom[ndom].wind_midz, sizeof (double), zdom[ndom].mdim, fptr);
 
     if (zdom[ndom].coord_type == CYLVAR)
     {
-      cylvar_allocate_domain (ndom);
-      fwrite (zdom[ndom].wind_z_var, sizeof (*zdom[ndom].wind_z_var), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
-      fwrite (zdom[ndom].wind_midz_var, sizeof (*zdom[ndom].wind_midz_var), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
+      fwrite (zdom[ndom].wind_z_var, sizeof (double), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
+      fwrite (zdom[ndom].wind_midz_var, sizeof (double), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
     }
   }
 
@@ -94,29 +93,23 @@ wind_save (filename)
 /* Write out the variable length arrays
 in the plasma structure */
 
-  for (ndom = 0; ndom < NPLASMA; ndom++)
+  for (m = 0; m < NPLASMA; m++)
   {
-    n += fwrite (plasmamain[ndom].density, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[ndom].partition, sizeof (double), nions, fptr);
-
-    n += fwrite (plasmamain[ndom].ioniz, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[ndom].recomb, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[ndom].inner_recomb, sizeof (double), nions, fptr);
-
-
-    n += fwrite (plasmamain[ndom].scatters, sizeof (int), nions, fptr);
-    n += fwrite (plasmamain[ndom].xscatters, sizeof (double), nions, fptr);
-
-    n += fwrite (plasmamain[ndom].heat_ion, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[ndom].cool_rr_ion, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[ndom].cool_dr_ion, sizeof (double), nions, fptr);
-    n += fwrite (plasmamain[ndom].lum_rr_ion, sizeof (double), nions, fptr);
-
-
-    n += fwrite (plasmamain[ndom].levden, sizeof (double), nlte_levels, fptr);
-    n += fwrite (plasmamain[ndom].recomb_simple, sizeof (double), nphot_total, fptr);
-    n += fwrite (plasmamain[ndom].recomb_simple_upweight, sizeof (double), nphot_total, fptr);
-    n += fwrite (plasmamain[ndom].kbf_use, sizeof (double), nphot_total, fptr);
+    n += fwrite (plasmamain[m].density, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].partition, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].ioniz, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].recomb, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].inner_recomb, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].scatters, sizeof (int), nions, fptr);
+    n += fwrite (plasmamain[m].xscatters, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].heat_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].cool_rr_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].cool_dr_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].lum_rr_ion, sizeof (double), nions, fptr);
+    n += fwrite (plasmamain[m].levden, sizeof (double), nlte_levels, fptr);
+    n += fwrite (plasmamain[m].recomb_simple, sizeof (double), nphot_total, fptr);
+    n += fwrite (plasmamain[m].recomb_simple_upweight, sizeof (double), nphot_total, fptr);
+    n += fwrite (plasmamain[m].kbf_use, sizeof (double), nphot_total, fptr);
   }
 
 /* Now write out the macro atom info */
@@ -124,25 +117,23 @@ in the plasma structure */
   if (geo.nmacro)
   {
     n += fwrite (macromain, sizeof (macro_dummy), NPLASMA, fptr);
-    for (ndom = 0; ndom < NPLASMA; ndom++)
+    for (m = 0; m < NPLASMA; m++)
     {
-      n += fwrite (macromain[ndom].jbar, sizeof (double), size_Jbar_est, fptr);
-      n += fwrite (macromain[ndom].jbar_old, sizeof (double), size_Jbar_est, fptr);
-      n += fwrite (macromain[ndom].gamma, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].gamma_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].gamma_e, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].gamma_e_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].alpha_st, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].alpha_st_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].alpha_st_e, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].alpha_st_e_old, sizeof (double), size_gamma_est, fptr);
-      n += fwrite (macromain[ndom].recomb_sp, sizeof (double), size_alpha_est, fptr);
-      n += fwrite (macromain[ndom].recomb_sp_e, sizeof (double), size_alpha_est, fptr);
-      n += fwrite (macromain[ndom].matom_emiss, sizeof (double), nlevels_macro, fptr);
-      n += fwrite (macromain[ndom].matom_abs, sizeof (double), nlevels_macro, fptr);
-
+      n += fwrite (macromain[m].jbar, sizeof (double), size_Jbar_est, fptr);
+      n += fwrite (macromain[m].jbar_old, sizeof (double), size_Jbar_est, fptr);
+      n += fwrite (macromain[m].gamma, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].gamma_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].gamma_e, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].gamma_e_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].alpha_st, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].alpha_st_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].alpha_st_e, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].alpha_st_e_old, sizeof (double), size_gamma_est, fptr);
+      n += fwrite (macromain[m].recomb_sp, sizeof (double), size_alpha_est, fptr);
+      n += fwrite (macromain[m].recomb_sp_e, sizeof (double), size_alpha_est, fptr);
+      n += fwrite (macromain[m].matom_emiss, sizeof (double), nlevels_macro, fptr);
+      n += fwrite (macromain[m].matom_abs, sizeof (double), nlevels_macro, fptr);
     }
-
   }
 
   fclose (fptr);
@@ -198,7 +189,7 @@ wind_read (filename)
      char filename[];
 {
   FILE *fptr;
-  int i;
+  int ndom;
   int n, m;
   char header[LINELENGTH];
   char version[LINELENGTH];
@@ -216,7 +207,6 @@ wind_read (filename)
   /* Now read in the geo structure */
 
   n += fread (&geo, sizeof (geo), 1, fptr);
-
 
   /* Read the atomic data file.  This is necessary to do here in order to establish the 
    * values for the dimensionality of some of the variable length structures, associated 
@@ -240,17 +230,18 @@ wind_read (filename)
   NPLASMA = geo.nplasma;
 
   n += fread (zdom, sizeof (domain_dummy), geo.ndomain, fptr);
-
-  for (i = 0; i < geo.ndomain; ++i)
+  for (ndom = 0; ndom < geo.ndomain; ++ndom)
   {
-    fread (zdom[i].wind_x, sizeof (*zdom[i].wind_x), zdom[i].ndim, fptr);
-    fread (zdom[i].wind_z, sizeof (*zdom[i].wind_z), zdom[i].mdim, fptr);
-    fread (zdom[i].wind_midx, sizeof (*zdom[i].wind_midx), zdom[i].ndim, fptr);
-    fread (zdom[i].wind_midz, sizeof (*zdom[i].wind_midz), zdom[i].mdim, fptr);
-    if (zdom[i].coord_type == CYLVAR)
+    allocate_domain_wind_coords (ndom);
+    fread (zdom[ndom].wind_x, sizeof (double), zdom[ndom].ndim, fptr);
+    fread (zdom[ndom].wind_z, sizeof (double), zdom[ndom].mdim, fptr);
+    fread (zdom[ndom].wind_midx, sizeof (double), zdom[ndom].ndim, fptr);
+    fread (zdom[ndom].wind_midz, sizeof (double), zdom[ndom].mdim, fptr);
+    if (zdom[ndom].coord_type == CYLVAR)
     {
-      fread (zdom[i].wind_z_var, sizeof (*zdom[i].wind_z_var), zdom[i].ndim * zdom[i].mdim, fptr);
-      fread (zdom[i].wind_midz_var, sizeof (*zdom[i].wind_midz_var), zdom[i].ndim * zdom[i].mdim, fptr);
+      cylvar_allocate_domain (ndom);
+      fread (zdom[ndom].wind_z_var, sizeof (double), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
+      fread (zdom[ndom].wind_midz_var, sizeof (double), zdom[ndom].ndim * zdom[ndom].mdim, fptr);
     }
   }
 
@@ -269,7 +260,6 @@ wind_read (filename)
   /*Allocate space for the dynamically allocated plasma arrays */
 
   calloc_dyn_plasma (NPLASMA);
-
 
   /* Read in the dynamically allocated plasma arrays */
 


### PR DESCRIPTION
The domain structure had some static allocations which were quite large. The PR merges in changes which dynamically allocate these static allocations to the amount required and also only (re-)allocates (to) the number of domains required.

This results in a roughly ~9x decrease in memory usage required for the domain structure.